### PR TITLE
Stop using a specific user

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,61 @@
 # github-actions
 
-This repo builds a Docker image which collects tooling used to setup environments. It serves as documentation of what tools and what versions are in use.
+This repo builds a Docker image which collects tooling used to setup environments. It serves as documentation of what tools and what versions are in use. Currently it contains primarily:
+
+- Terraform
+- Packer
+
+## Using
+
+An example Makefile that makes use of this container might look like this:
+```
+SHELL:=/bin/bash
+
+SUFFIX="tfstate<4 random digits>"
+IMAGE="ghcr.io/xenitab/github-actions/tools:latest"
+OPA_BLAST_RADIUS := $(if $(OPA_BLAST_RADIUS), $(OPA_BLAST_RADIUS), 50)
+AZURE_CONFIG_DIR := $(if $(AZURE_CONFIG_DIR), $(AZURE_CONFIG_DIR), "$${HOME}/.azure")
+TTY_OPTIONS=$(shell [ -t 0 ] && echo '-it')
+ifndef ENV
+$(error Need to set ENV)
+endif
+ifndef DIR
+$(error Need to set DIR)
+endif
+
+prepare:
+        docker run --user $(shell id -u) $(TTY_OPTIONS) --entrypoint "/opt/terraform.sh" -v $${PWD}/$(DIR)/.terraform/$(ENV).env:/tmp/$(ENV).env -v $(AZURE_CONFIG_DIR):/work/.azure -v $${PWD}/$(DIR):/tmp/$(DIR) -v $${PWD}/global.tfvars:/tmp/global.tfvars $(IMAGE) prepare $(DIR) $(ENV) $(SUFFIX)
+
+plan:
+        docker run --user $(shell id -u) $(TTY_OPTIONS) --entrypoint "/opt/terraform.sh" -v $${PWD}/$(DIR)/.terraform/$(ENV).env:/tmp/$(ENV).env -v $(AZURE_CONFIG_DIR):/work/.azure -v $${PWD}/$(DIR):/tmp/$(DIR) -v $${PWD}/global.tfvars:/tmp/global.tfvars $(IMAGE) plan $(DIR) $(ENV) $(SUFFIX) $(OPA_BLAST_RADIUS)
+
+apply:
+        docker run --user $(shell id -u) $(TTY_OPTIONS) --entrypoint "/opt/terraform.sh" -v $${PWD}/$(DIR)/.terraform/$(ENV).env:/tmp/$(ENV).env -v $(AZURE_CONFIG_DIR):/work/.azure -v $${PWD}/$(DIR):/tmp/$(DIR) -v $${PWD}/global.tfvars:/tmp/global.tfvars $(IMAGE) apply $(DIR) $(ENV) $(SUFFIX)
+
+destroy:
+        docker run --user $(shell id -u) $(TTY_OPTIONS) --entrypoint "/opt/terraform.sh" -v $${PWD}/$(DIR)/.terraform/$(ENV).env:/tmp/$(ENV).env -v $(AZURE_CONFIG_DIR):/work/.azure -v $${PWD}/$(DIR):/tmp/$(DIR) -v $${PWD}/global.tfvars:/tmp/global.tfvars $(IMAGE) destroy $(DIR) $(ENV) $(SUFFIX)
+
+state-remove:
+        docker run --user $(shell id -u) $(TTY_OPTIONS) --entrypoint "/opt/terraform.sh" -v $${PWD}/$(DIR)/.terraform/$(ENV).env:/tmp/$(ENV).env -v $(AZURE_CONFIG_DIR):/work/.azure -v $${PWD}/$(DIR):/tmp/$(DIR) -v $${PWD}/global.tfvars:/tmp/global.tfvars $(IMAGE) state-remove $(DIR) $(ENV) $(SUFFIX)
+
+validate:
+        docker run --user $(shell id -u) $(TTY_OPTIONS) --entrypoint "/opt/terraform.sh" -v $${PWD}/$(DIR)/.terraform/$(ENV).env:/tmp/$(ENV).env -v $(AZURE_CONFIG_DIR):/work/.azure -v $${PWD}/$(DIR):/tmp/$(DIR) -v $${PWD}/global.tfvars:/tmp/global.tfvars $(IMAGE) validate $(DIR) $(ENV) $(SUFFIX)
+```
 
 ## Building
 
-Build the tooling image:
+Build the tooling image:s
 ```shell
-docker build docker/
+docker build -t dev docker/
+```
+
+## Releasing
+
+In order to push a new image to the container registry, you create a new release from the GitHub UI or via the API. The publish release event will trigger a GitHub pipeline that deploys the container from the release tag.
+
+If you need to push a custom image to the registry, you need to go to your GitHub [personal access tokens](https://github.com/settings/tokens) page and create an access token. That token is your password when logging in:
+```
+docker login ghcr.io --username <GITHUB_USERNAME>
+docker build -t ghcr.io/xenitab/github-actions/tools:<TAG> ./docker
+docker push ghcr.io/xenitab/github-actions/tools:<TAG>
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # github-actions
-Shared GitHub Actions
+
+This repo builds a Docker image which collects tooling used to setup environments. It serves as documentation of what tools and what versions are in use.
+
+## Building
+
+Build the tooling image:
+```shell
+docker build docker/
+```

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,16 +9,8 @@ RUN GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o tf-prepare main.go
 
 FROM alpine:3.12.1
 
-ENV USER="tools"
-ENV GROUP="tools"
-
-RUN mkdir -p /tmp/install
+RUN mkdir -p /tmp/install /usr/src /work
 WORKDIR /tmp/install
-
-RUN addgroup -g 1000 -S ${GROUP} && \
-    adduser -S --ingroup ${GROUP} --uid 1000 ${USER}
-
-RUN mkdir -p /usr/src
 
 # libc6-compat is needed to load local terraform providers
 RUN apk update && \
@@ -46,17 +38,17 @@ RUN /usr/src/install-scripts/packer.sh --version="1.6.5" --sha="a49f6408a50c220f
 
 # Install tflint
 COPY install-scripts/tflint.sh /usr/src/install-scripts/tflint.sh
-RUN /usr/src/install-scripts/tflint.sh --version="v0.24.1" --sha="2dbe3b423f5d3e0bb458d51761c97d51a4fd6c3d7bd1efd87c4aa3dc5199e7b2" --user="${USER}"
-COPY config/.tflint.hcl /home/${USER}/.tflint.d/.tflint.hcl
+RUN /usr/src/install-scripts/tflint.sh --version="v0.24.1" --sha="2dbe3b423f5d3e0bb458d51761c97d51a4fd6c3d7bd1efd87c4aa3dc5199e7b2"
+COPY config/.tflint.hcl /work/.tflint.d/.tflint.hcl
 
 # Install tflint ruleset
 COPY install-scripts/tflint-ruleset.sh /usr/src/install-scripts/tflint-ruleset.sh
-RUN /usr/src/install-scripts/tflint-ruleset.sh --ruleset="azurerm" --version="v0.8.2" --sha="4ef97bbc847bde194401c3206eb127fffaf4ce430127e0408878a8a833242a30" --user="${USER}" --group="${GROUP}"
-RUN /usr/src/install-scripts/tflint-ruleset.sh --ruleset="aws" --version="v0.2.1" --sha="ec2a992a8413227e2321d985b62cde34bc34287599894f966b0fc8904aba0d8a" --user="${USER}" --group="${GROUP}"
+RUN /usr/src/install-scripts/tflint-ruleset.sh --ruleset="azurerm" --version="v0.8.2" --sha="4ef97bbc847bde194401c3206eb127fffaf4ce430127e0408878a8a833242a30"
+RUN /usr/src/install-scripts/tflint-ruleset.sh --ruleset="aws" --version="v0.2.1" --sha="ec2a992a8413227e2321d985b62cde34bc34287599894f966b0fc8904aba0d8a"
 
 # Install terraform (tfenv)
 COPY install-scripts/tfenv.sh /usr/src/install-scripts/tfenv.sh
-RUN /usr/src/install-scripts/tfenv.sh --latest-terraform-version="0.15.3" --tfenv-version="v2.2.2" --user="${USER}" --group="${GROUP}"
+RUN /usr/src/install-scripts/tfenv.sh --latest-terraform-version="0.15.3" --tfenv-version="v2.2.2"
 
 # Install tfsec
 COPY install-scripts/tfsec.sh /usr/src/install-scripts/tfsec.sh
@@ -103,6 +95,6 @@ COPY opa-policies /opt/opa-policies
 COPY terraform.sh /opt/terraform.sh
 COPY packer.sh /opt/packer.sh
 
-USER ${USER}
+ENV HOME=/work
 
-WORKDIR /home/${USER}
+WORKDIR /work

--- a/docker/install-scripts/tfenv.sh
+++ b/docker/install-scripts/tfenv.sh
@@ -9,12 +9,6 @@ while [ $# -gt 0 ]; do
     --tfenv-version=*)
       TFENV_VERSION="${1#*=}"
       ;;
-    --user=*)
-      USER="${1#*=}"
-      ;;
-    --group=*)
-      GROUP="${1#*=}"
-      ;;
     *)
       echo "Error: Invalid argument."
       exit 1
@@ -28,5 +22,3 @@ ln -s /opt/tfenv/bin/* /usr/local/bin
 #tfenv list-remote | grep -v "-" | grep ${LATEST_TERRAFORM_VERSION} -A 4 | xargs -t -I % tfenv install %
 tfenv install ${LATEST_TERRAFORM_VERSION}
 tfenv use ${LATEST_TERRAFORM_VERSION}
-
-chown -R ${USER}:${GROUP} /opt/tfenv

--- a/docker/install-scripts/tflint-ruleset.sh
+++ b/docker/install-scripts/tflint-ruleset.sh
@@ -12,12 +12,6 @@ while [ $# -gt 0 ]; do
     --sha=*)
       SHA="${1#*=}"
       ;;
-    --user=*)
-      USER="${1#*=}"
-      ;;
-    --group=*)
-      GROUP="${1#*=}"
-      ;;
     *)
       echo "Error: Invalid argument."
       exit 1
@@ -35,6 +29,5 @@ fi
 
 unzip tflint-ruleset-${RULESET}_linux_amd64.zip
 rm tflint-ruleset-${RULESET}_linux_amd64.zip
-mkdir -p /home/${USER}/.tflint.d/plugins/
-mv tflint-ruleset-${RULESET} /home/${USER}/.tflint.d/plugins/tflint-ruleset-${RULESET}
-chown -R ${USER}:${GROUP} /home/${USER}/.tflint.d
+mkdir -p /work/.tflint.d/plugins/
+mv tflint-ruleset-${RULESET} /work/.tflint.d/plugins/tflint-ruleset-${RULESET}

--- a/docker/install-scripts/tflint.sh
+++ b/docker/install-scripts/tflint.sh
@@ -9,9 +9,6 @@ while [ $# -gt 0 ]; do
     --sha=*)
       SHA="${1#*=}"
       ;;
-    --user=*)
-      USER="${1#*=}"
-      ;;
     *)
       echo "Error: Invalid argument."
       exit 1
@@ -30,4 +27,4 @@ fi
 unzip tflint_linux_amd64.zip
 rm tflint_linux_amd64.zip
 mv tflint /usr/local/bin/tflint
-mkdir -p /home/${USER}/.tflint.d
+mkdir -p /work/.tflint.d

--- a/docker/terraform.sh
+++ b/docker/terraform.sh
@@ -17,7 +17,7 @@ BACKEND_NAME="sa${ENVIRONMENT}${RG_LOCATION_SHORT}${SUFFIX}"
 CONTAINER_NAME="tfstate-${DIR}"
 ENVIRONMENT_FILE="/tmp/${ENVIRONMENT}.env"
 
-export HELM_CACHE_HOME=/tmp/.cache 
+export HELM_CACHE_HOME=/tmp/${DIR}/.helm_cache
 
 if [ -z "${OPA_BLAST_RADIUS}" ]; then
   OPA_BLAST_RADIUS=50

--- a/docker/terraform.sh
+++ b/docker/terraform.sh
@@ -150,7 +150,7 @@ validate () {
   terraform validate
   terraform fmt .
   terraform fmt variables/
-  tflint --config="/home/${USER}/.tflint.d/.tflint.hcl" --var-file="variables/${ENVIRONMENT}.tfvars" --var-file="variables/common.tfvars" --var-file="../global.tfvars" .
+  tflint --config="/work/.tflint.d/.tflint.hcl" --var-file="variables/${ENVIRONMENT}.tfvars" --var-file="variables/common.tfvars" --var-file="../global.tfvars" .
   tfsec .
 }
 

--- a/docker/terraform.sh
+++ b/docker/terraform.sh
@@ -76,7 +76,7 @@ apply () {
   sops --decrypt --azure-kv ${SOPS_KEY_ID} .terraform/plans/${ENVIRONMENT}.enc > .terraform/plans/${ENVIRONMENT}
   rm -rf .terraform/plans/${ENVIRONMENT}.enc
   set +e
-  terraform apply ".terraform/plans/${ENVIRONMENT}"
+  env HELM_CACHE_HOME=/tmp/.cache terraform apply ".terraform/plans/${ENVIRONMENT}"
   EXIT_CODE=$?
   set -e
   rm -rf .terraform/plans/${ENVIRONMENT}

--- a/docker/terraform.sh
+++ b/docker/terraform.sh
@@ -17,6 +17,8 @@ BACKEND_NAME="sa${ENVIRONMENT}${RG_LOCATION_SHORT}${SUFFIX}"
 CONTAINER_NAME="tfstate-${DIR}"
 ENVIRONMENT_FILE="/tmp/${ENVIRONMENT}.env"
 
+export HELM_CACHE_HOME=/tmp/.cache 
+
 if [ -z "${OPA_BLAST_RADIUS}" ]; then
   OPA_BLAST_RADIUS=50
 fi
@@ -76,7 +78,7 @@ apply () {
   sops --decrypt --azure-kv ${SOPS_KEY_ID} .terraform/plans/${ENVIRONMENT}.enc > .terraform/plans/${ENVIRONMENT}
   rm -rf .terraform/plans/${ENVIRONMENT}.enc
   set +e
-  env HELM_CACHE_HOME=/tmp/.cache terraform apply ".terraform/plans/${ENVIRONMENT}"
+  terraform apply ".terraform/plans/${ENVIRONMENT}"
   EXIT_CODE=$?
   set -e
   rm -rf .terraform/plans/${ENVIRONMENT}


### PR DESCRIPTION
The current setup effectively assumes UID 1000 is used outside the container. Better to require the executer to tell us what UID to use with e.g. `docker run --user $(id -u)`. That way, any files created by the container (or by Docker helpfully creating mount *sources* that does not exist) will be owned by the executing user.