### PR TITLE
Fail properly if we cannot create storage account

### DIFF
--- a/docker/go-tf-prepare/pkg/azure/azure.go
+++ b/docker/go-tf-prepare/pkg/azure/azure.go
@@ -95,7 +95,8 @@ func CreateStorageAccount(ctx context.Context, config azureConfig) error {
 		}
 
 		if !*res.CheckNameAvailabilityResult.NameAvailable {
-			log.Error(err, "client.CheckNameAvailability: Azure Storage Account Name not available", "storageAccountName", storageAccountName)
+			err := fmt.Errorf("Azure Storage Account Name '%s' not available", storageAccountName)
+			log.Error(err, "azure.CreateStorageAccount")
 			return err
 		}
 


### PR DESCRIPTION
E.g. because it is part of a different subscription.

Please note that the current code is a bit confusing in that it has already bailed if `err` is not `nil` but still returns `err` :unamused: 