### PR TITLE
Upgrade AZ cli to 2.30.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,7 +22,7 @@ RUN /usr/src/install-scripts/base.sh
 
 # Install Azure CLI
 COPY install-scripts/azure-cli.sh /usr/src/install-scripts/azure-cli.sh
-RUN /usr/src/install-scripts/azure-cli.sh --version="2.15.1"
+RUN /usr/src/install-scripts/azure-cli.sh --version="2.30.0"
 
 # Install AWS CLI
 COPY install-scripts/aws-cli.sh /usr/src/install-scripts/aws-cli.sh


### PR DESCRIPTION
Recently Azure changed a bit how there login worked and creating a bug that causes older versions of AZ cli to not be compatible with the new ones. https://github.com/Azure/azure-cli/issues/20154

Since we are using AZ cli together with Azure login github action and they followed along to this new feature we started seeing this issue. More information can be found here: https://github.com/Azure/login/issues/162
To mitigate this in the future azure login hopefully will introduce a way of setting which az cli version to use: https://github.com/Azure/login/issues/164
Then we could solve this on the CI level instead.
