### PR TITLE
Update tools

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ COPY ./go-tf-prepare/main.go main.go
 COPY ./go-tf-prepare/pkg/ pkg/
 RUN GOOS=linux GOARCH=amd64 GO111MODULE=on go build -o tf-prepare main.go
 
-FROM debian:11.1-slim
+FROM debian:11.4-slim
 
 #Base
 RUN apt-get update -y && \
@@ -22,41 +22,41 @@ WORKDIR /tmp/install
 
 # Install Azure CLI
 COPY install-scripts/azure-cli.sh /usr/src/install-scripts/azure-cli.sh
-RUN /usr/src/install-scripts/azure-cli.sh --version="2.30.0"
+RUN /usr/src/install-scripts/azure-cli.sh --version="2.39.0"
 
 # Install AWS CLI
 COPY install-scripts/aws-cli.sh /usr/src/install-scripts/aws-cli.sh
-RUN /usr/src/install-scripts/aws-cli.sh --version="2.1.10"
+RUN /usr/src/install-scripts/aws-cli.sh --version="2.7.21"
 
 # Install tflint
 COPY install-scripts/tflint.sh /usr/src/install-scripts/tflint.sh
-RUN /usr/src/install-scripts/tflint.sh --version="v0.34.1" --sha="5a3d254c5e8222e15afea5da61a7ab66d560c31f302a47cbb90ed69c6dc973ec"
+RUN /usr/src/install-scripts/tflint.sh --version="v0.39.2" --sha="2a56e42db112ac5ae32ab31f37bee8c0803333eeb85556597935a95adb25f654"
 COPY config/.tflint.hcl /work/.tflint.d/.tflint.hcl
 
 # Install tflint ruleset
 COPY install-scripts/tflint-ruleset.sh /usr/src/install-scripts/tflint-ruleset.sh
-RUN /usr/src/install-scripts/tflint-ruleset.sh --ruleset="azurerm" --version="v0.14.0" --sha="63a1e9b2502516144d62643d37e2ff6bba1e795305b0e7e7d6a8bb8f0cabf2b2"
-RUN /usr/src/install-scripts/tflint-ruleset.sh --ruleset="aws" --version="v0.12.0" --sha="1f8e54f5504c91f1bba4cf47ad749d8bec64b7f1786837f3d39921246bdfe15a"
+RUN /usr/src/install-scripts/tflint-ruleset.sh --ruleset="azurerm" --version="v0.17.1" --sha="302ce68e9f8a88718e0d59d6737c718526c4f814ecce775489a8cd2d4014fdbe"
+RUN /usr/src/install-scripts/tflint-ruleset.sh --ruleset="aws" --version="v0.15.0" --sha="8aa7da4ec5e02884763a0bab89a717f0e33004469c3a846810c82ea59df64ed6"
 
 # Install terraform (tfenv)
 COPY install-scripts/tfenv.sh /usr/src/install-scripts/tfenv.sh
-RUN /usr/src/install-scripts/tfenv.sh --latest-terraform-version="1.1.7" --tfenv-version="v2.2.2"
+RUN /usr/src/install-scripts/tfenv.sh --latest-terraform-version="1.2.6" --tfenv-version="v3.0.0"
 
 # Install tfsec
 COPY install-scripts/tfsec.sh /usr/src/install-scripts/tfsec.sh
-RUN /usr/src/install-scripts/tfsec.sh --version="v1.8.0" --sha="6f0ffcc204a73991fb2b47561bbdf473e98a9566036c0f36b95d9574fd5ab4ce"
+RUN /usr/src/install-scripts/tfsec.sh --version="v1.27.1" --sha="edf06ce4897a3113dda6393b31345aea8b70626dac4c67df87ef0b69fd6c83f0"
 
 # Install Open Policy Agent
 COPY install-scripts/opa.sh /usr/src/install-scripts/opa.sh
-RUN /usr/src/install-scripts/opa.sh --version="v0.40.0" --sha="fc77b0fd2efffb60f0d65d22c251b780c15a8e298d5034f41439a7f3d3183f97"
+RUN /usr/src/install-scripts/opa.sh --version="v0.43.0" --sha="d5337139a7ccb04149bd9f96ab7a1641a3e3c39f6e1fffa610c7a5c054b0881f"
 
 # Install sops
 COPY install-scripts/sops.sh /usr/src/install-scripts/sops.sh
-RUN /usr/src/install-scripts/sops.sh --version="v3.6.1" --sha="b2252aa00836c72534471e1099fa22fab2133329b62d7826b5ac49511fcc8997"
+RUN /usr/src/install-scripts/sops.sh --version="v3.7.3" --sha="53aec65e45f62a769ff24b7e5384f0c82d62668dd96ed56685f649da114b4dbb"
 
 # Install GitHub CLI
 COPY install-scripts/github-cli.sh /usr/src/install-scripts/github-cli.sh
-RUN /usr/src/install-scripts/github-cli.sh --version="1.3.0" --sha="56e540ddc978908fd236d53b00855c3526936392976e18bf429161963bbd45ec"
+RUN /usr/src/install-scripts/github-cli.sh --version="2.14.3" --sha="95fe2e93bbd7a9f02d5b22cee01a53ab6d581fda8fa170364b668d142840ef58"
 
 # Install jq
 COPY install-scripts/jq.sh /usr/src/install-scripts/jq.sh
@@ -64,15 +64,15 @@ RUN /usr/src/install-scripts/jq.sh --version="1.6" --sha="af986793a515d500ab2d35
 
 # Install yq
 COPY install-scripts/yq.sh /usr/src/install-scripts/yq.sh
-RUN /usr/src/install-scripts/yq.sh --version="2.11.1"
+RUN /usr/src/install-scripts/yq.sh --version="3.1.0"
 
 # Install kubectl
 COPY install-scripts/kubectl.sh /usr/src/install-scripts/kubectl.sh
-RUN /usr/src/install-scripts/kubectl.sh --version="v1.19.0" --sha="79bb0d2f05487ff533999a639c075043c70a0a1ba25c1629eb1eef6ebe3ba70f"
+RUN /usr/src/install-scripts/kubectl.sh --version="v1.24.3" --sha="8a45348bdaf81d46caf1706c8bf95b3f431150554f47d444ffde89e8cdd712c1"
 
 # Install helm
 COPY install-scripts/helm.sh /usr/src/install-scripts/helm.sh
-RUN /usr/src/install-scripts/helm.sh --version="v3.4.1" --sha="538f85b4b73ac6160b30fd0ab4b510441aa3fa326593466e8bf7084a9c288420"
+RUN /usr/src/install-scripts/helm.sh --version="v3.9.2" --sha="3f5be38068a1829670440ccf00b3b6656fd90d0d9cfd4367539f3b13e4c20531"
 
 COPY --from=tf-prepare-builder /workspace/tf-prepare /usr/local/bin/tf-prepare
 RUN chmod +x /usr/local/bin/tf-prepare


### PR DESCRIPTION
Changes:
- Update base image: `debian:11.1-slim` -> `debian:11.4-slim`
- Update Azure CLI: `2.30.0` -> `2.39.0`
- Update AWS CLI: `2.1.10` -> `2.7.21`
- Update tflint: `v0.34.1` -> `v0.39.2`
- Update tflint azurerm ruleset: `v0.14.0` -> `v0.17.1`
- Update tflint aws ruleset: `v0.12.0` -> `v0.15.0`
- Update terraform: `1.1.7` -> `1.2.6`
- Update tfenv: `v2.2.2` -> `v3.0.0`
- Update tfsec: `v1.8.0` -> `v1.27.1`
- Update opa: `v0.40.0` -> `v0.43.0`
- Update GitHub CLI: `1.3.0` -> `2.14.3`
- Update yq: `2.11.1` -> `3.1.0`
- Update kubectl: `v1.19.0` -> `v1.24.3`
- Update helm: `v3.4.1` -> `v3.9.2`