### PR TITLE
Switch to using GITHUB_TOKEN when authing to CR

### DIFF
--- a/.github/workflows/tools-container-latest.yaml
+++ b/.github/workflows/tools-container-latest.yaml
@@ -19,11 +19,11 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push container image
         uses: docker/build-push-action@v2

--- a/.github/workflows/tools-container-tag.yaml
+++ b/.github/workflows/tools-container-tag.yaml
@@ -19,11 +19,11 @@ jobs:
         uses: docker/setup-buildx-action@v1
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get GitHub Tag
         id: get_tag


### PR DESCRIPTION
CR_PAT is mysteriously absent from configuration, but we should anyway not use PATs now that GITHUB_TOKEN exists.